### PR TITLE
ASB-28068: Geometry Table Capitalization Handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,5 @@
-ADQLLib/build/**
-UWSLib/build/**
-TAPLib/build/**
 /nbproject/private/
+/build/
 /dist/
 /bin/
 /reports/

--- a/src/adql/translator/MAST_Geometry_SQLServerTranslator.java
+++ b/src/adql/translator/MAST_Geometry_SQLServerTranslator.java
@@ -129,12 +129,15 @@ public class MAST_Geometry_SQLServerTranslator extends SQLServerTranslator {
 	}
 	
 	private String ReplaceTableNames(String input, String newValue) {
-		for (int iGeometryTable = 0; iGeometryTable < CatalogTableNames.length; ++iGeometryTable){	
-			if(input.contains(CatalogTableNames[iGeometryTable]))
-				input = input.replace(CatalogTableNames[iGeometryTable], newValue);
+		input = input.toLowerCase();
+		for(int iGeometryTable = 0; iGeometryTable < this.CatalogTableNames.length; ++iGeometryTable) {
+			String geoTableName = this.CatalogTableNames[iGeometryTable].toLowerCase();
+		   if (input.contains(geoTableName)) {
+			  input = input.replace(geoTableName, newValue);
+		   }
 		}
 		return input;
-	}
+	 }
 	
 	// Only qualify these once; avoid calling multiple times in nested subquery parsing
 	private String QualifyUserFunctionNames(String input) {


### PR DESCRIPTION
Adds some simple handling for the errors we saw when the capitalization of the geometry table name in the ServiceConfig.xml document of the ADQL translator and the table name returned by the `/tables` response differ.

Also reverts an errant push of mine to the gitignore for the `st_main` branch.