### PR TITLE
ASB-35975: Incorrect translation with mutiple negative operands

### DIFF
--- a/.github/workflows/adqllib.yml
+++ b/.github/workflows/adqllib.yml
@@ -14,6 +14,6 @@ jobs:
       - name: Checkout project sources
         uses: actions/checkout@v6
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v3
+        uses: gradle/actions/setup-gradle@v6
       - name: Run build with Gradle Wrapper
         run: ./gradlew :ADQLLib:test

--- a/.github/workflows/adqllib.yml
+++ b/.github/workflows/adqllib.yml
@@ -12,8 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout project sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/actions/setup-gradle@v3
       - name: Run build with Gradle Wrapper
         run: ./gradlew :ADQLLib:test

--- a/ADQLLib/src/adql/translator/JDBCTranslator.java
+++ b/ADQLLib/src/adql/translator/JDBCTranslator.java
@@ -814,7 +814,7 @@ public abstract class JDBCTranslator implements ADQLTranslator {
 
 	@Override
 	public String translate(Operation op) throws TranslationException {
-		return "(" + translate(op.getLeftOperand()) + op.getOperation().toADQL() + translate(op.getRightOperand()) + ")";
+		return translate(op.getLeftOperand()) + op.getOperation().toADQL() + translate(op.getRightOperand());
 	}
 
 	/* ************************ */

--- a/ADQLLib/test/adql/db/TestSubQueries.java
+++ b/ADQLLib/test/adql/db/TestSubQueries.java
@@ -98,7 +98,7 @@ public class TestSubQueries {
 		try {
 			ADQLSet query = adqlParser.parseQuery("SELECT t.* FROM (SELECT (ra+ra_error) AS x, (dec+dec_error) AS Y, pmra AS \"ProperMotion\" FROM table2) AS t");
 			assertEquals("SELECT t.*\nFROM (SELECT (ra+ra_error) AS x , (dec+dec_error) AS Y , pmra AS \"ProperMotion\"\nFROM table2) AS t", query.toADQL());
-			assertEquals("SELECT \"t\".\"x\" AS \"x\" , \"t\".\"y\" AS \"y\" , \"t\".\"ProperMotion\" AS \"ProperMotion\"\nFROM (SELECT ((\"public\".\"table2\".\"ra\"+\"public\".\"table2\".\"ra_error\")) AS \"x\" , ((\"public\".\"table2\".\"dec\"+\"public\".\"table2\".\"dec_error\")) AS \"y\" , \"public\".\"table2\".\"pmra\" AS \"ProperMotion\"\nFROM \"public\".\"table2\") AS \"t\"", (new PostgreSQLTranslator()).translate(query));
+			assertEquals("SELECT \"t\".\"x\" AS \"x\" , \"t\".\"y\" AS \"y\" , \"t\".\"ProperMotion\" AS \"ProperMotion\"\nFROM (SELECT (\"public\".\"table2\".\"ra\"+\"public\".\"table2\".\"ra_error\") AS \"x\" , (\"public\".\"table2\".\"dec\"+\"public\".\"table2\".\"dec_error\") AS \"y\" , \"public\".\"table2\".\"pmra\" AS \"ProperMotion\"\nFROM \"public\".\"table2\") AS \"t\"", (new PostgreSQLTranslator()).translate(query));
 		} catch(Exception ex) {
 			ex.printStackTrace(System.err);
 			fail("No error expected! (see console for more details)");

--- a/ADQLLib/test/adql/translator/TestJDBCTranslator.java
+++ b/ADQLLib/test/adql/translator/TestJDBCTranslator.java
@@ -3,7 +3,6 @@ package adql.translator;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.fail;
 
 import java.util.ArrayList;

--- a/ADQLLib/test/adql/translator/TestJDBCTranslator.java
+++ b/ADQLLib/test/adql/translator/TestJDBCTranslator.java
@@ -67,8 +67,8 @@ public class TestJDBCTranslator {
         try {
             ADQLParser parser = new ADQLParser(ADQLVersion.V2_1);
             JDBCTranslator translator = new AJDBCTranslator();
-            ADQLSet query = parser.parseQuery("SELECT (FOO-1-2) FROM BAR");
-            assertTrue(translator.translate(query).contains("(FOO-1-2)"));
+            ADQLSet query = parser.parseQuery("SELECT (1-2-3) FROM BAR");
+            assertTrue(translator.translate(query).contains("(1-2-3)"));
         } catch(ParseException pe) {
             pe.printStackTrace();
             fail("The given ADQL query is completely correct. No error should have occurred while parsing it. (see the console for more details)");

--- a/ADQLLib/test/adql/translator/TestJDBCTranslator.java
+++ b/ADQLLib/test/adql/translator/TestJDBCTranslator.java
@@ -3,6 +3,7 @@ package adql.translator;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.fail;
 
 import java.util.ArrayList;
@@ -58,6 +59,25 @@ public class TestJDBCTranslator {
 	@Before
 	public void setUp() throws Exception {
 	}
+
+	@Test
+    public void testExtraParenOperandsMain21() {
+        // MAST TAP based on ADQL 2.1 branch is incorrectly applying parens in arithmetic statements with >2 items.
+        // This is causing incorrect results for negative values. Testing where this fails in upstream branches.
+        try {
+			ADQLParser parser = new ADQLParser(ADQLVersion.V2_1);
+            JDBCTranslator translator = new AJDBCTranslator();
+            ADQLSet query = parser.parseQuery("SELECT (FOO-1-2) FROM BAR");
+            System.out.println(translator.translate(query));
+            assertFalse(translator.translate(query).contains("((FOO-(1-2))"));
+        } catch(ParseException pe) {
+            pe.printStackTrace();
+            fail("The given ADQL query is completely correct. No error should have occurred while parsing it. (see the console for more details)");
+        } catch (TranslationException te) {
+            te.printStackTrace();
+            fail("No error was expected from this translation. (see the console for more details)");
+        }
+    }
 
 	@Test
 	public void testTranslateSetOperation() {

--- a/ADQLLib/test/adql/translator/TestJDBCTranslator.java
+++ b/ADQLLib/test/adql/translator/TestJDBCTranslator.java
@@ -60,16 +60,15 @@ public class TestJDBCTranslator {
 	public void setUp() throws Exception {
 	}
 
-	@Test
-    public void testExtraParenOperandsMain21() {
-        // MAST TAP based on ADQL 2.1 branch is incorrectly applying parens in arithmetic statements with >2 items.
-        // This is causing incorrect results for negative values. Testing where this fails in upstream branches.
+    @Test
+    public void testExtraParenOperandsIn21() {
+        // Testing a bug introduced upstream in 2.1 has not regressed.
+        // It added parens, changing query logic in cases with multiple negative values.
         try {
-			ADQLParser parser = new ADQLParser(ADQLVersion.V2_1);
+            ADQLParser parser = new ADQLParser(ADQLVersion.V2_1);
             JDBCTranslator translator = new AJDBCTranslator();
             ADQLSet query = parser.parseQuery("SELECT (FOO-1-2) FROM BAR");
-            System.out.println(translator.translate(query));
-            assertFalse(translator.translate(query).contains("((FOO-(1-2))"));
+            assertTrue(translator.translate(query).contains("(FOO-1-2)"));
         } catch(ParseException pe) {
             pe.printStackTrace();
             fail("The given ADQL query is completely correct. No error should have occurred while parsing it. (see the console for more details)");


### PR DESCRIPTION
This is the fix in upstream ADQLLib library for https://github.com/gmantele/vollt/issues/169 where 1-2-3 becomes (1-(2-3)), silently providing incorrect results. The upstream package maintainer noted where code had regressed in his ADQL 2.1 branch, which we are using.

This appears to be the only case where the extra parentheses and therefore bug were introduced.

It is being run on mastdev currently, in a branch of the ADQLtoDBTranslator, https://github.com/spacetelescope/ADQL-translator-service/tree/refs/heads/ASB-35975-negative-operand, and deployed on devmastresolver.

See corrected mastdev: https://mastdev.stsci.edu/vo-tap/api/v0.1/roman_catalogs/sync?LANG=ADQL&format=json&QUERY=SELECT%201-2-3%20from%20tap_schema.schemas
vs incorrect masttest: https://masttest.stsci.edu/vo-tap/api/v0.1/roman_catalogs/sync?LANG=ADQL&format=json&QUERY=SELECT%201-2-3%20from%20tap_schema.schemas

Also updated CI actions and tests.

Note 'st_main' is our main branch with ST specific additions (for MSSQL spatial queries), 'main' is kept for syncing upstream changes. Gregory is not making this fix upstream yet.