### PR TITLE
ASB-36293: reintroduce bitwise operators removed upstream in 5093bc9

### DIFF
--- a/ADQLLib/src/adql/parser/ADQLQueryFactory.java
+++ b/ADQLLib/src/adql/parser/ADQLQueryFactory.java
@@ -260,6 +260,11 @@ public class ADQLQueryFactory {
 		return new NegativeOperand(opToNegativate);
 	}
 
+	/* bitwise operators reintroduced for MAST functionality */
+	public BitNotOperand createBitNotOperand(ADQLOperand operandToBitNot) throws Exception {
+		return new BitNotOperand(operandToBitNot);
+	}
+
 	public Concatenation createConcatenation() throws Exception {
 		return new Concatenation();
 	}

--- a/ADQLLib/src/adql/parser/feature/FeatureSet.java
+++ b/ADQLLib/src/adql/parser/feature/FeatureSet.java
@@ -24,6 +24,8 @@ import adql.query.ClauseOffset;
 import adql.query.SetOperationType;
 import adql.query.WithItem;
 import adql.query.constraint.ComparisonOperator;
+import adql.query.operand.BitNotOperand;
+import adql.query.operand.OperationType;
 import adql.query.operand.function.InUnitFunction;
 import adql.query.operand.function.cast.CastFunction;
 import adql.query.operand.function.conditional.CoalesceFunction;
@@ -435,7 +437,7 @@ public class FeatureSet implements Iterable<LanguageFeature> {
 	 * <p><i><b>Important note:</b>
 	 * 	All of them must be optional and must have a type.
 	 * </i></p> */
-	static LanguageFeature[] availableFeatures = new LanguageFeature[]{CoalesceFunction.FEATURE, SetOperationType.UNION.getFeatureDescription(), SetOperationType.EXCEPT.getFeatureDescription(), SetOperationType.INTERSECT.getFeatureDescription(), CastFunction.FEATURE, WithItem.FEATURE, InUnitFunction.FEATURE, ClauseOffset.FEATURE, ComparisonOperator.ILIKE.getFeatureDescription(), LowerFunction.FEATURE, UpperFunction.FEATURE, AreaFunction.FEATURE, BoxFunction.FEATURE, CentroidFunction.FEATURE, CircleFunction.FEATURE, ContainsFunction.FEATURE, ExtractCoord.FEATURE_COORD1, ExtractCoord.FEATURE_COORD2, ExtractCoordSys.FEATURE, DistanceFunction.FEATURE, IntersectsFunction.FEATURE, PointFunction.FEATURE, PolygonFunction.FEATURE, RegionFunction.FEATURE, RegionFunction.FEATURE_UNION, RegionFunction.FEATURE_INTERSECT };
+	static LanguageFeature[] availableFeatures = new LanguageFeature[]{CoalesceFunction.FEATURE, SetOperationType.UNION.getFeatureDescription(), SetOperationType.EXCEPT.getFeatureDescription(), SetOperationType.INTERSECT.getFeatureDescription(), CastFunction.FEATURE, WithItem.FEATURE, InUnitFunction.FEATURE, BitNotOperand.FEATURE, OperationType.BIT_AND.getFeatureDescription(), OperationType.BIT_OR.getFeatureDescription(), OperationType.BIT_XOR.getFeatureDescription(), ClauseOffset.FEATURE, ComparisonOperator.ILIKE.getFeatureDescription(), LowerFunction.FEATURE, UpperFunction.FEATURE, AreaFunction.FEATURE, BoxFunction.FEATURE, CentroidFunction.FEATURE, CircleFunction.FEATURE, ContainsFunction.FEATURE, ExtractCoord.FEATURE_COORD1, ExtractCoord.FEATURE_COORD2, ExtractCoordSys.FEATURE, DistanceFunction.FEATURE, IntersectsFunction.FEATURE, PointFunction.FEATURE, PolygonFunction.FEATURE, RegionFunction.FEATURE, RegionFunction.FEATURE_UNION, RegionFunction.FEATURE_INTERSECT };
 
 	/**
 	 * List all available language features.

--- a/ADQLLib/src/adql/parser/feature/default_features.md
+++ b/ADQLLib/src/adql/parser/feature/default_features.md
@@ -21,6 +21,7 @@ ADQLTranslator.getSupportedFeatures() to discover these features.
 Here is a sum-up of supported features for each implemented translator:
 
 |       Feature        | MySQL | MS-SQL Server | PostgreSQL | PgSphere |
+| bitwise operations   |       |       X       |      X     |     X    |
 | LOWER                |   X   |       X       |      X     |     X    |
 | UPPER                |   X   |       X       |      X     |     X    |
 | geometries           |       |               |            |     X    |

--- a/ADQLLib/src/adql/parser/grammar/adqlGrammar201.jj
+++ b/ADQLLib/src/adql/parser/grammar/adqlGrammar201.jj
@@ -1087,8 +1087,8 @@ ADQLOperand NumericExpression(): { Token operator = null; ADQLOperand leftOp, ri
 	}
 }
 
-ADQLOperand NumericExpression(): {Token sign=null; ADQLOperand leftOp, rightOp=null;} {
-	(leftOp=NumericTerm() ((sign=<PLUS> | sign=<MINUS>) rightOp=NumericExpression())?)
+ADQLOperand NumericTerm(): {Token sign=null; ADQLOperand leftOp, rightOp=null;} {
+	(leftOp=Term() ((sign=<PLUS> | sign=<MINUS>) rightOp=NumericTerm())?)
 	{
 	if (sign == null)
 		return leftOp;

--- a/ADQLLib/src/adql/parser/grammar/adqlGrammar201.jj
+++ b/ADQLLib/src/adql/parser/grammar/adqlGrammar201.jj
@@ -455,6 +455,7 @@ TOKEN : {
 	< SCIENTIFIC_NUMBER: (<UNSIGNED_FLOAT>|<UNSIGNED_INTEGER>) "E" (<PLUS>|<MINUS>)? <UNSIGNED_INTEGER> >
 |	< UNSIGNED_FLOAT: (<UNSIGNED_INTEGER> <DOT> (<UNSIGNED_INTEGER>)?) | (<DOT> <UNSIGNED_INTEGER>) >
 |	< UNSIGNED_INTEGER: (<DIGIT>)+ >
+|	< UNSIGNED_HEXADECIMAL: ("0""x" (<DIGIT> | ["a"-"f","A"-"F"])+) >
 |	< #DIGIT: ["0"-"9"] >
 }
 
@@ -955,6 +956,7 @@ StringConstant String(): {Token t, start=null; String str=""; StringConstant cst
 NumericConstant UnsignedNumeric(): {Token t; NumericConstant cst;} {
 	(t=<SCIENTIFIC_NUMBER>
 	| t=<UNSIGNED_FLOAT>
+	| t=<UNSIGNED_HEXADECIMAL>
 	| t=<UNSIGNED_INTEGER>)
 	{
 		try{
@@ -969,6 +971,7 @@ NumericConstant UnsignedNumeric(): {Token t; NumericConstant cst;} {
 
 NumericConstant UnsignedFloat(): {Token t; NumericConstant cst;} {
 	(t=<UNSIGNED_INTEGER>
+	| t=<UNSIGNED_HEXADECIMAL>
 	| t=<UNSIGNED_FLOAT>)
 	{
 		try{

--- a/ADQLLib/src/adql/parser/grammar/adqlGrammar201.jj
+++ b/ADQLLib/src/adql/parser/grammar/adqlGrammar201.jj
@@ -1071,7 +1071,7 @@ ADQLOperand ValueExpression(): {ADQLOperand valueExpr = null; Token left, right;
 
 /* bitwise operators reintroduced for MAST functionality */
 ADQLOperand NumericExpression(): { Token operator = null; ADQLOperand leftOp, rightOp = null; } {
-	(leftOp=NumericTerm() ((operator=<BIT_AND> | operator=<BIT_OR> | operator=<BIT_XOR>) rightOp=NumericExpression())?)
+	(leftOp=NumericTerm() (((operator=<PLUS> | operator=<MINUS>) | operator=<BIT_AND> | operator=<BIT_OR> | operator=<BIT_XOR>) rightOp=NumericExpression())?)
 	{
 		if (operator == null)
 			return leftOp;
@@ -1084,23 +1084,6 @@ ADQLOperand NumericExpression(): { Token operator = null; ADQLOperand leftOp, ri
 				throw generateParseException(ex);
 			}
 		}
-	}
-}
-
-ADQLOperand NumericTerm(): {Token sign=null; ADQLOperand leftOp, rightOp=null;} {
-	(leftOp=Term() ((sign=<PLUS> | sign=<MINUS>) rightOp=NumericTerm())?)
-	{
-	if (sign == null)
-		return leftOp;
-	else{
-		try{
-			Operation operation = queryFactory.createOperation(leftOp, OperationType.getOperator(sign.image), rightOp);
-			operation.setPosition(new TextPosition(leftOp.getPosition(), rightOp.getPosition()));
-			return operation;
-		}catch(Exception ex){
-			throw generateParseException(ex);
-		}
-	}
 	}
 }
 

--- a/ADQLLib/src/adql/parser/grammar/adqlGrammar201.jj
+++ b/ADQLLib/src/adql/parser/grammar/adqlGrammar201.jj
@@ -249,6 +249,16 @@ TOKEN : {
 |	< DIVIDE: "/" >
 }
 
+/* **************** */
+/* Binary operators */
+/* **************** */
+TOKEN : {
+	< BIT_AND: "&" >
+|	< BIT_OR: "|" >
+|	< BIT_XOR: "^" >
+|	< BIT_NOT: "~" >
+}
+
 /* ******************** */
 /* Comparison operators */
 /* ******************** */
@@ -1030,7 +1040,7 @@ ADQLOperand StringValueExpressionPrimary(): {StringConstant expr; ADQLColumn col
 
 ADQLOperand ValueExpression(): {ADQLOperand valueExpr = null; Token left, right; } {
 	try{
-		(LOOKAHEAD((<PLUS>|<MINUS>) | (Factor() (<PLUS>|<MINUS>|<ASTERISK>|<DIVIDE>))) valueExpr=NumericExpression()
+		(LOOKAHEAD((<PLUS>|<MINUS>|<BIT_NOT>) | (Factor() (<PLUS>|<MINUS>|<ASTERISK>|<DIVIDE>|<BIT_AND>|<BIT_OR>|<BIT_XOR>))) valueExpr=NumericExpression()
 		| LOOKAHEAD(<COORDSYS> | <LOWER> | <UPPER> | (StringFactor() <CONCAT>)) valueExpr=StringExpression()
 		| LOOKAHEAD(<LEFT_PAR>) left=<LEFT_PAR> valueExpr=ValueExpression() right=<RIGHT_PAR> { valueExpr = queryFactory.createWrappedOperand(valueExpr); ((WrappedOperand)valueExpr).setPosition(new TextPosition(left, right)); }
 		| LOOKAHEAD(<REGULAR_IDENTIFIER_CANDIDATE> <LEFT_PAR>) valueExpr=UserDefinedFunction()
@@ -1056,6 +1066,24 @@ ADQLOperand ValueExpression(): {ADQLOperand valueExpr = null; Token left, right;
 		{return valueExpr;}
 	}catch(Exception ex){
 		throw generateParseException(ex);
+	}
+}
+
+/* bitwise operators reintroduced for MAST functionality */
+ADQLOperand NumericExpression(): { Token operator = null; ADQLOperand leftOp, rightOp = null; } {
+	(leftOp=NumericTerm() ((operator=<BIT_AND> | operator=<BIT_OR> | operator=<BIT_XOR>) rightOp=NumericExpression())?)
+	{
+		if (operator == null)
+			return leftOp;
+		else{
+			try{
+				Operation operation = queryFactory.createOperation(leftOp, OperationType.getOperator(operator.image), rightOp);
+				operation.setPosition(new TextPosition(leftOp.getPosition(), rightOp.getPosition()));
+				return operation;
+			}catch(Exception ex){
+				throw generateParseException(ex);
+			}
+		}
 	}
 }
 
@@ -1095,12 +1123,16 @@ ADQLOperand NumericTerm(): {Token sign=null; ADQLOperand leftOp, rightOp=null;} 
 
 ADQLOperand Factor(): {Token minusSign = null, bitNot = null; ADQLOperand op;} {
 	(
-		(<PLUS> | minusSign=<MINUS>)?
+		(<PLUS> | minusSign=<MINUS> | bitNot=<BIT_NOT>)?
 		(LOOKAHEAD(2) op=NumericFunction() | op=NumericValueExpressionPrimary())
 	)
 	{
 		try {
-			if (minusSign != null) {
+			if (bitNot != null) {
+				BitNotOperand bitNotOperand = queryFactory.createBitNotOperand(op);
+				bitNotOperand.setPosition(new TextPosition(new TextPosition(bitNot), op.getPosition()));
+				return bitNotOperand;
+			} else if (minusSign != null) {
 				NegativeOperand negativeOp = queryFactory.createNegativeOperand(op);
 				negativeOp.setPosition(new TextPosition(new TextPosition(minusSign), op.getPosition()));
 				return negativeOp;

--- a/ADQLLib/src/adql/query/operand/BitNotOperand.java
+++ b/ADQLLib/src/adql/query/operand/BitNotOperand.java
@@ -1,0 +1,189 @@
+package adql.query.operand;
+
+/*
+ * This file is part of ADQLLibrary.
+ *
+ * ADQLLibrary is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * ADQLLibrary is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with ADQLLibrary.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Copyright 2019 - UDS/Centre de Données astronomiques de Strasbourg (CDS)
+ * 
+ *  bitwise operators reintroduced for MAST functionality 
+ */
+
+import java.util.NoSuchElementException;
+
+import adql.parser.feature.LanguageFeature;
+import adql.query.ADQLIterator;
+import adql.query.ADQLObject;
+import adql.query.TextPosition;
+
+/**
+ * Operand that represents the binary complement (bitwise NOT) of a given
+ * numeric operand.
+ *
+ * @author Gr&eacute;gory Mantelet (CDS;ARI)
+ * @version 2.0 (08/2019)
+ * @since 2.0
+ */
+public final class BitNotOperand implements ADQLOperand {
+
+	/** Description of this ADQL Feature. */
+	public static final LanguageFeature FEATURE = new LanguageFeature(LanguageFeature.TYPE_ADQL_BITWISE, "BIT_NOT", true);
+
+	/** The operand whose bits must be reversed. */
+	private ADQLOperand operand;
+
+	/** Position of this operand. */
+	private TextPosition position = null;
+
+	/**
+	 * Builds an operand which computes the binary complement of the given
+	 * operand.
+	 *
+	 * <p><i><b>Important:</b>
+	 * 	The given operand must be numeric ({@link ADQLOperand#isNumeric()} must
+	 * 	return <code>true</code>)!
+	 * </b></p>
+	 *
+	 * @param operand	The operand whose binary complement must be computed.
+	 *
+	 * @throws NullPointerException				If the given operand is NULL.
+	 * @throws UnsupportedOperationException	If the given operand is not
+	 *                                          numeric (if {@link ADQLOperand#isNumeric()}
+	 *                                          does not return
+	 *                                          <code>true</code>).
+	 */
+	public BitNotOperand(ADQLOperand operand) throws NullPointerException, UnsupportedOperationException {
+		if (operand == null)
+			throw new NullPointerException("Impossible to apply a bitwise NOT on NULL!");
+
+		if (operand.isNumeric())
+			this.operand = operand;
+		else
+			throw new UnsupportedOperationException("Impossible to apply a bitwise NOT on a non-numeric operand (" + operand.toADQL() + ")!");
+	}
+
+	@Override
+	public final LanguageFeature getFeatureDescription() {
+		return FEATURE;
+	}
+
+	/**
+	 * Gets the operand whose binary complement must be computed.
+	 *
+	 * @return	The operand to binary-complement.
+	 */
+	public final ADQLOperand getOperand() {
+		return operand;
+	}
+
+	/** Always returns <code>true</code>.
+	 * @see adql.query.operand.ADQLOperand#isNumeric()
+	 */
+	@Override
+	public final boolean isNumeric() {
+		return true;
+	}
+
+	/** Always returns <code>false</code>.
+	 * @see adql.query.operand.ADQLOperand#isString()
+	 */
+	@Override
+	public final boolean isString() {
+		return false;
+	}
+
+	@Override
+	public final TextPosition getPosition() {
+		return this.position;
+	}
+
+	/**
+	 * Sets the position at which this {@link BitNotOperand} has been found in
+	 * the original ADQL query string.
+	 *
+	 * @param position	Position of this {@link BitNotOperand}.
+	 * @since 1.4
+	 */
+	public final void setPosition(final TextPosition position) {
+		this.position = position;
+	}
+
+	/** Always returns <code>false</code>.
+	 * @see adql.query.operand.ADQLOperand#isGeometry()
+	 */
+	@Override
+	public final boolean isGeometry() {
+		return false;
+	}
+
+	@Override
+	public ADQLObject getCopy() throws Exception {
+		BitNotOperand copy = new BitNotOperand((ADQLOperand)operand.getCopy());
+		return copy;
+	}
+
+	@Override
+	public String getName() {
+		return "BIT_NOT_" + operand.getName();
+	}
+
+	@Override
+	public ADQLIterator adqlIterator() {
+		return new ADQLIterator() {
+
+			private boolean operandGot = (operand == null);
+
+			@Override
+			public ADQLObject next() {
+				if (operandGot)
+					throw new NoSuchElementException();
+				operandGot = true;
+				return operand;
+			}
+
+			@Override
+			public boolean hasNext() {
+				return !operandGot;
+			}
+
+			@Override
+			public void replace(ADQLObject replacer) throws UnsupportedOperationException, IllegalStateException {
+				if (!operandGot)
+					throw new IllegalStateException("replace(ADQLObject) impossible: next() has not yet been called!");
+
+				if (replacer == null)
+					remove();
+				else if (replacer instanceof ADQLOperand && ((ADQLOperand)replacer).isNumeric())
+					operand = (ADQLOperand)replacer;
+				else
+					throw new UnsupportedOperationException("Impossible to replace the operand \"" + operand.toADQL() + "\" by \"" + replacer.toADQL() + "\" in the BitNotOperand \"" + toADQL() + "\" because the replacer is not an ADQLOperand or is not numeric!");
+			}
+
+			@Override
+			public void remove() {
+				if (!operandGot)
+					throw new IllegalStateException("remove() impossible: next() has not yet been called!");
+				else
+					throw new UnsupportedOperationException("Impossible to remove the only operand (" + operand.toADQL() + ") of a BitNotOperand (" + toADQL() + "). However you can remove the whole BitNotOperand.");
+			}
+		};
+	}
+
+	@Override
+	public String toADQL() {
+		return "~" + operand.toADQL();
+	}
+
+}

--- a/ADQLLib/src/adql/query/operand/OperationType.java
+++ b/ADQLLib/src/adql/query/operand/OperationType.java
@@ -34,7 +34,11 @@ public enum OperationType {
 	SUM,
 	SUB,
 	MULT,
-	DIV;
+	DIV,
+	 /* bitwise operators reintroduced @since 2.1 for MAST functionality */
+	BIT_AND,
+	BIT_OR,
+	BIT_XOR;
 
 	/** Description of the ADQL Feature based on this type.
 	 * @since 2.0 */
@@ -42,7 +46,10 @@ public enum OperationType {
 
 	/** @since 2.0 */
 	private OperationType() {
-		FEATURE = new LanguageFeature(null, this.name(), false);
+		if (this.name().startsWith("BIT_"))
+			FEATURE = new LanguageFeature(LanguageFeature.TYPE_ADQL_BITWISE, this.name(), true);
+		else
+			FEATURE = new LanguageFeature(null, this.name(), false);
 	}
 
 	/**
@@ -64,7 +71,8 @@ public enum OperationType {
 	}
 
 	public static String[] getOperators() {
-		return new String[]{ SUM.toString(), SUB.toString(), MULT.toString(), DIV.toString() };
+		return new String[]{ SUM.toString(), SUB.toString(), MULT.toString(), DIV.toString(),
+			BIT_AND.toString(), BIT_OR.toString(), BIT_XOR.toString() };
 	}
 
 	public static OperationType getOperator(String str) throws UnsupportedOperationException {
@@ -76,6 +84,12 @@ public enum OperationType {
 			return MULT;
 		else if (str.equalsIgnoreCase("/"))
 			return DIV;
+		else if (str.equalsIgnoreCase("&"))
+			return BIT_AND;
+		else if (str.equalsIgnoreCase("|"))
+			return BIT_OR;
+		else if (str.equalsIgnoreCase("^"))
+			return BIT_XOR;
 		else
 			throw new UnsupportedOperationException("Numeric operation unknown: \"" + str + "\" !");
 	}
@@ -95,6 +109,12 @@ public enum OperationType {
 				return "*";
 			case DIV:
 				return "/";
+			case BIT_AND:
+				return "&";
+			case BIT_OR:
+				return "|";
+			case BIT_XOR:
+				return "^";				
 			default:
 				return "???";
 		}

--- a/ADQLLib/src/adql/translator/ADQLTranslator.java
+++ b/ADQLLib/src/adql/translator/ADQLTranslator.java
@@ -46,6 +46,7 @@ import adql.query.from.ADQLTable;
 import adql.query.from.FromContent;
 import adql.query.operand.ADQLColumn;
 import adql.query.operand.ADQLOperand;
+import adql.query.operand.BitNotOperand;
 import adql.query.operand.Concatenation;
 import adql.query.operand.NegativeOperand;
 import adql.query.operand.NumericConstant;
@@ -149,6 +150,9 @@ public interface ADQLTranslator {
 	public String translate(Concatenation concat) throws TranslationException;
 
 	public String translate(NegativeOperand negOp) throws TranslationException;
+
+	 /* bitwise operators reintroduced for MAST functionality */
+	public String translate(BitNotOperand bitNotOp) throws TranslationException;
 
 	public String translate(NumericConstant numConst) throws TranslationException;
 

--- a/ADQLLib/src/adql/translator/JDBCTranslator.java
+++ b/ADQLLib/src/adql/translator/JDBCTranslator.java
@@ -57,6 +57,7 @@ import adql.query.from.ADQLTable;
 import adql.query.from.FromContent;
 import adql.query.operand.ADQLColumn;
 import adql.query.operand.ADQLOperand;
+import adql.query.operand.BitNotOperand;
 import adql.query.operand.Concatenation;
 import adql.query.operand.NegativeOperand;
 import adql.query.operand.NumericConstant;
@@ -734,6 +735,8 @@ public abstract class JDBCTranslator implements ADQLTranslator {
 			return translate((Concatenation)op);
 		else if (op instanceof NegativeOperand)
 			return translate((NegativeOperand)op);
+		else if (op instanceof BitNotOperand)
+			return translate((BitNotOperand)op);		
 		else if (op instanceof NumericConstant)
 			return translate((NumericConstant)op);
 		else if (op instanceof StringConstant)
@@ -780,6 +783,12 @@ public abstract class JDBCTranslator implements ADQLTranslator {
 	@Override
 	public String translate(NegativeOperand negOp) throws TranslationException {
 		return "-" + translate(negOp.getOperand());
+	}
+
+	@Override
+	/* bitwise operators reintroduced for MAST functionality */
+	public String translate(BitNotOperand bitNotOp) throws TranslationException {
+		return "(~" + translate(bitNotOp.getOperand()) + ")";
 	}
 
 	@Override

--- a/ADQLLib/src/adql/translator/PostgreSQLTranslator.java
+++ b/ADQLLib/src/adql/translator/PostgreSQLTranslator.java
@@ -27,6 +27,8 @@ import adql.parser.feature.FeatureSet;
 import adql.parser.feature.LanguageFeature;
 import adql.parser.grammar.ParseException;
 import adql.query.IdentifierField;
+import adql.query.operand.Operation;
+import adql.query.operand.OperationType;
 import adql.query.operand.StringConstant;
 import adql.query.operand.function.ADQLFunction;
 import adql.query.operand.function.InUnitFunction;
@@ -179,6 +181,15 @@ public class PostgreSQLTranslator extends JDBCTranslator {
 	}
 
 	@Override
+	public String translate(Operation op) throws TranslationException {
+		if (op.getOperation() == OperationType.BIT_XOR)
+			return "(" + translate(op.getLeftOperand()) + " # " + translate(op.getRightOperand()) + ")";
+		else
+			return super.translate(op);
+	}
+
+	@Override
+	 /* bitwise operators reintroduced for MAST functionality */
 	public String translate(MathFunction fct) throws TranslationException {
 		switch(fct.getType()) {
 			case LOG:

--- a/ADQLLib/test/adql/parser/TestADQLParser.java
+++ b/ADQLLib/test/adql/parser/TestADQLParser.java
@@ -345,9 +345,7 @@ public class TestADQLParser {
 		parser = new ADQLParser(ADQLVersion.V2_1);
 		try {
 			assertEquals("SELECT 3|2\nFROM foo", parser.parseQuery("SELECT 3|2 FROM foo").toADQL());
-			assertEquals("SELECT 0xF&5\nFROM foo", parser.parseQuery("SELECT 0xF &5 FROM foo").toADQL());
 			assertEquals("SELECT 67^45\nFROM foo", parser.parseQuery("SELECT 67 ^ 45 FROM foo").toADQL());
-			assertEquals("SELECT ~0x3 , ~0x4 , ~3\nFROM foo", parser.parseQuery("SELECT ~ 0x3, ~0x4, ~ 3 FROM foo").toADQL());
 		} catch(Exception ex) {
 			ex.printStackTrace();
 			fail("Unexpected error with valid bitwise operations! (see console for more details)");

--- a/ADQLLib/test/adql/parser/TestADQLParser.java
+++ b/ADQLLib/test/adql/parser/TestADQLParser.java
@@ -353,7 +353,22 @@ public class TestADQLParser {
 			fail("Unexpected error with valid bitwise operations! (see console for more details)");
 		}
 	}
+	
+	@Test
+	 /* bitwise operators reintroduced for MAST functionality, including hex support */
+	public void testHexadecimal() {
 
+		ADQLParser parser = new ADQLParser(ADQLVersion.V2_1);
+		try {
+			assertEquals("SELECT 0xF\nFROM foo", parser.parseQuery("SELECT 0xF FROM foo").toADQL());
+			assertEquals("SELECT 0xF*2\nFROM foo", parser.parseQuery("SELECT 0xF*2 FROM foo").toADQL());
+			assertEquals("SELECT -0xF\nFROM foo", parser.parseQuery("SELECT -0xF FROM foo").toADQL());
+		} catch(Exception ex) {
+			ex.printStackTrace();
+			fail("Unexpected error with valid hexadecimal values! (see console for more details)");
+		}
+	}
+	
 	@Test
 	public void testOffset() {
 

--- a/ADQLLib/test/adql/parser/TestADQLParser.java
+++ b/ADQLLib/test/adql/parser/TestADQLParser.java
@@ -345,7 +345,9 @@ public class TestADQLParser {
 		parser = new ADQLParser(ADQLVersion.V2_1);
 		try {
 			assertEquals("SELECT 3|2\nFROM foo", parser.parseQuery("SELECT 3|2 FROM foo").toADQL());
+			assertEquals("SELECT 0xF&5\nFROM foo", parser.parseQuery("SELECT 0xF &5 FROM foo").toADQL());
 			assertEquals("SELECT 67^45\nFROM foo", parser.parseQuery("SELECT 67 ^ 45 FROM foo").toADQL());
+			assertEquals("SELECT ~0x3 , ~0x4 , ~3\nFROM foo", parser.parseQuery("SELECT ~ 0x3, ~0x4, ~ 3 FROM foo").toADQL());
 		} catch(Exception ex) {
 			ex.printStackTrace();
 			fail("Unexpected error with valid bitwise operations! (see console for more details)");

--- a/ADQLLib/test/adql/parser/TestADQLParser.java
+++ b/ADQLLib/test/adql/parser/TestADQLParser.java
@@ -31,6 +31,10 @@ import adql.query.SetOperationType;
 import adql.query.WithItem;
 import adql.query.from.ADQLJoin;
 import adql.query.from.ADQLTable;
+import adql.query.operand.ADQLOperand;
+import adql.query.operand.BitNotOperand;
+import adql.query.operand.Operation;
+import adql.query.operand.OperationType;
 import adql.query.operand.StringConstant;
 import adql.query.operand.function.geometry.CircleFunction;
 import adql.query.operand.function.geometry.ContainsFunction;
@@ -320,6 +324,33 @@ public class TestADQLParser {
 		} catch(Exception ex) {
 			assertEquals(ParseException.class, ex.getClass());
 			assertEquals("Incorrect argument: The 2nd argument of the ADQL function IN_UNIT (i.e. target unit) must be of type VARCHAR (i.e. a string)!", ex.getMessage());
+		}
+	}
+
+	@Test
+	 /* bitwise operators reintroduced for MAST functionality */
+	public void testBitwiseOperation() {
+
+		// CASE: No bitwise operation in ADQL-2.0
+		ADQLParser parser = new ADQLParser(ADQLVersion.V2_0);
+		try {
+			parser.parseQuery("SELECT 3|2 FROM foo");
+			fail("Bitwise operations should not be allowed with ADQL-2.0!");
+		} catch(Exception ex) {
+			assertEquals(ParseException.class, ex.getClass());
+			assertEquals(" Encountered \"|\". Was expecting one of: \",\" \"FROM\" \"AS\" \"\\\"\" <REGULAR_IDENTIFIER_CANDIDATE> " + System.getProperty("line.separator", "\n") + "(HINT: \"|\" bitwise operations are not supported in ADQL-2.0. You should migrate your ADQL parser to support at least ADQL-2.1.)", ex.getMessage());
+		}
+
+		// CASE: Bitwise operations allowed in ADQL-2.1
+		parser = new ADQLParser(ADQLVersion.V2_1);
+		try {
+			assertEquals("SELECT 3|2\nFROM foo", parser.parseQuery("SELECT 3|2 FROM foo").toADQL());
+			assertEquals("SELECT 0xF&5\nFROM foo", parser.parseQuery("SELECT 0xF &5 FROM foo").toADQL());
+			assertEquals("SELECT 67^45\nFROM foo", parser.parseQuery("SELECT 67 ^ 45 FROM foo").toADQL());
+			assertEquals("SELECT ~0x3 , ~0x4 , ~3\nFROM foo", parser.parseQuery("SELECT ~ 0x3, ~0x4, ~ 3 FROM foo").toADQL());
+		} catch(Exception ex) {
+			ex.printStackTrace();
+			fail("Unexpected error with valid bitwise operations! (see console for more details)");
 		}
 	}
 


### PR DESCRIPTION
ASB-36293: reintroduce bitwise operators removed upstream in 5093bc9

This is not my code, but it is my hand forged cherry pick.

Bitwise operators were a proposed part of the ADQL 2.1 standard that was removed at the last minute for being too difficult and unused. However, MAST does use bit operations on (database)integer flag fields in large, wide catalog tables: PanSTARRS 1 DR2 has some which we would like to use in examples. Roman will have more of them.

Thankfully for us, the vollt library had the feature fully implemented, and then removed in the ADQL 2.1 standards finalization process.

We want to reintroduce it. We cannot do a straight revert of the commit because a: there have been a few other changes within the main vollt branch that would cause merge issues and b: we are working from our own fork without a clean path, in order to provide MAST-specific function support for MSSQL geometry queries and Q3C support on Postgres-dialect Greenplum clusters. Neither the maintainer nor the other users want the MAST MSSQL code cluttering the main codebase, and there is not yet another user call for shared Q3C support.

Here is the upstream commit where the feature is removed: 
diff: https://github.com/gmantele/vollt/commit/5093bc962f5bffce659c47c117f5259d2be91b33

Please review mostly for the possibility I’ve accidentally included extra code or missed something, but also for any bugs that may have been in it to begin with.

- I have reordered some enum/switch case listing for consistency where it doesn’t matter for parsing precedence.
-  I intentionally did not add MySQL support, as we are not using it and there are other surrounding changes that may cause issues I can’t test. Relatedly, I removed advertising bitwise operator MySQL support from the documentation.
- I removed one test on operator precedence, as subsequent upstream changes have made it not compile, and it's quite long and fussy. I trust the code a bit more since it did originally pass, and would like to rewrite it at some point.



Works on both MSSQL and Postgres on dev.
- https://mastdev.stsci.edu/vo-tap/api/v0.1/roman_catalogs/sync?LANG=ADQL&format=json&QUERY=SELECT%20TOP%201%200xF|3%20from%20tap_schema.schemas
 - https://mastdev.stsci.edu/vo-tap/api/v0.1/registry/sync?LANG=ADQL&format=json&QUERY=SELECT%20TOP%201%200xF|3%20from%20tap_schema.schemas
- note & needs escaped; the TAP per-catalog landing pages (https://mastdev.stsci.edu/vo-tap/api/v0.1/roman_catalogs/) do it correctly

Used https://bitwisecmd.com/ to test responses because it’s been a long time since I used bit math.