### PR TITLE
Asb 38057 operator precedence

### DIFF
--- a/ADQLLib/src/adql/parser/feature/LanguageFeature.java
+++ b/ADQLLib/src/adql/parser/feature/LanguageFeature.java
@@ -303,6 +303,9 @@ public final class LanguageFeature {
 	/** Root IVOID for all the TAPRegExt's language features. */
 	public final static String IVOID_TAP_REGEXT = "ivo://ivoa.net/std/TAPRegExt";
 
+	/** Root IVOID for custom MAST language features. */
+	public final static String IVOID_MAST_REGEXT = "ivo://edu.stsci.archive/std/exts";
+
 	/** User Defined Functions. */
 	public final static String TYPE_UDF = IVOID_TAP_REGEXT + "#features-udf";
 
@@ -328,7 +331,7 @@ public final class LanguageFeature {
 	public final static String TYPE_ADQL_UNIT = IVOID_TAP_REGEXT + "#features-adql-unit";
 
 	/** Bit manipulation functions. */
-	public final static String TYPE_ADQL_BITWISE = IVOID_TAP_REGEXT + "#features-adql-bitwise";
+	public final static String TYPE_ADQL_BITWISE = IVOID_MAST_REGEXT + "#features-adql-bitwise";
 
 	/** Query result offset. */
 	public final static String TYPE_ADQL_OFFSET = IVOID_TAP_REGEXT + "#features-adql-offset";

--- a/ADQLLib/test/adql/parser/TestADQLParser.java
+++ b/ADQLLib/test/adql/parser/TestADQLParser.java
@@ -353,6 +353,28 @@ public class TestADQLParser {
 			fail("Unexpected error with valid bitwise operations! (see console for more details)");
 		}
 	}
+
+	@Test
+     /* with bitwise operators reintroduced for MAST functionality */
+    public void testOperatorPrecedence() {
+        ADQLParser parser = new ADQLParser(ADQLVersion.V2_1);
+        try {
+            /* test general precedence where upstream code has failed */
+            assertEquals("SELECT 1-2-3\nFROM foo", parser.parseQuery("SELECT 1-2-3 FROM foo").toADQL());
+
+            /* test precedence with bitwise operators */
+            /* note math clause goes straight to database, where the db handles it to its own liking */
+            /* if mssql and postgres are different, should we document or override? */
+            assertEquals("SELECT 1+2&3\nFROM foo", parser.parseQuery("SELECT 1+2&3 FROM foo").toADQL());
+            assertEquals("SELECT 1&2|3\nFROM foo", parser.parseQuery("SELECT 1&2|3 FROM foo").toADQL());
+            assertEquals("SELECT 1&(2+3)\nFROM foo", parser.parseQuery("SELECT 1&(2+3) FROM foo").toADQL());
+            assertEquals("SELECT 1&2+3\nFROM foo", parser.parseQuery("SELECT 1&2+3 FROM foo").toADQL());
+            assertEquals("SELECT 1|2&3\nFROM foo", parser.parseQuery("SELECT 1|2&3 FROM foo").toADQL());
+        } catch(Exception ex) {
+            ex.printStackTrace();
+            fail("Unexpected error with valid bitwise operations! (see console for more details)");
+        }
+    }
 	
 	@Test
 	 /* bitwise operators reintroduced for MAST functionality, including hex support */


### PR DESCRIPTION
Added tests confirming the vollt library passes down a variety of test queries verbatim, no bugs with added parens as we saw with 1-2-3.

Changed documenting info for the LanguageFeature to match TAP's custom /capabilities announcement. This may not be visible the way we are using the library, but it should be correct anyway.

[postgresql](https://www.postgresql.org/docs/7.2/sql-precedence.html) and mssql actually have different internal operator precedence. Postgresql nature should be documented somewhere for the postgres/greenplum catalogs as the back end matters. I don't want to tackle longstanding standards disagreement for this.

