### PR TITLE
Use q3c_join instead of q3c_dist

### DIFF
--- a/ADQLLib/src/adql/translator/MAST_Q3CTranslator.java
+++ b/ADQLLib/src/adql/translator/MAST_Q3CTranslator.java
@@ -1,0 +1,74 @@
+package adql.translator;
+
+import adql.query.constraint.Comparison;
+import adql.query.constraint.ComparisonOperator;
+import adql.query.operand.function.geometry.ContainsFunction;
+import adql.query.operand.function.geometry.DistanceFunction;
+import adql.query.operand.function.geometry.IntersectsFunction;
+
+/**
+ * MAST-specific Postgres/Q3C translator.
+ *
+ * This class intentionally keeps the default Q3C behavior in place until the
+ * MAST-specific DISTANCE/CONTAINS/INTERSECTS semantics are implemented.
+ */
+public class MAST_Q3CTranslator extends Q3CTranslator {
+
+    public MAST_Q3CTranslator() {
+        super(false);
+    }
+
+    public MAST_Q3CTranslator(boolean allCaseSensitive) {
+        super(allCaseSensitive);
+    }
+
+    public MAST_Q3CTranslator(boolean catalog, boolean schema, boolean table, boolean column) {
+        super(catalog, schema, table, column);
+    }
+
+    public String translate(DistanceFunction fct, final String radius) throws TranslationException {
+        StringBuffer str = new StringBuffer("q3c_join(");
+        str.append(translate(fct.getP1())).append(",");
+        str.append(translate(fct.getP2())).append(",");
+        str.append(radius);
+        str.append(")");
+        str.append(" = 1"); 
+        return str.toString();
+    }
+
+    @Override
+    public String translate(ContainsFunction fct) throws TranslationException {
+        return super.translate(fct);
+    }
+
+    @Override
+    public String translate(IntersectsFunction fct) throws TranslationException {
+        return super.translate(fct);
+    }
+
+    @Override
+    public String translate(Comparison comp) throws TranslationException {
+        if ((comp.getLeftOperand() instanceof ContainsFunction || comp.getLeftOperand() instanceof IntersectsFunction)
+                &&
+                (comp.getOperator() == ComparisonOperator.EQUAL || comp.getOperator() == ComparisonOperator.NOT_EQUAL)
+                && comp.getRightOperand().isNumeric())
+            return translate(comp.getLeftOperand()) + " " + comp.getOperator().toADQL() + " '"
+                    + translate(comp.getRightOperand()) + "'";
+        else if ((comp.getRightOperand() instanceof ContainsFunction
+                || comp.getRightOperand() instanceof IntersectsFunction)
+                && (comp.getOperator() == ComparisonOperator.EQUAL || comp.getOperator() == ComparisonOperator.NOT_EQUAL)
+                && comp.getLeftOperand().isNumeric())
+            return "'" + translate(comp.getLeftOperand()) + "' " + comp.getOperator().toADQL() + " "
+                    + translate(comp.getRightOperand());
+        else if ((comp.getLeftOperand() instanceof DistanceFunction)
+                && (comp.getOperator() == ComparisonOperator.LESS_THAN || comp.getOperator() == ComparisonOperator.LESS_OR_EQUAL)
+                && comp.getRightOperand().isNumeric())
+            return translate((DistanceFunction) comp.getLeftOperand(), translate(comp.getRightOperand()).toString());
+        else if ((comp.getRightOperand() instanceof DistanceFunction)
+                && (comp.getOperator() == ComparisonOperator.LESS_THAN || comp.getOperator() == ComparisonOperator.LESS_OR_EQUAL)
+                && comp.getLeftOperand().isNumeric())
+            return translate((DistanceFunction) comp.getRightOperand(), translate(comp.getLeftOperand()).toString());
+        else
+            return super.translate(comp);
+    }
+}

--- a/ADQLLib/src/adql/translator/MAST_Q3CTranslator.java
+++ b/ADQLLib/src/adql/translator/MAST_Q3CTranslator.java
@@ -39,11 +39,11 @@ public class MAST_Q3CTranslator extends Q3CTranslator {
         if ((comp.getLeftOperand() instanceof DistanceFunction)
                 && (comp.getOperator() == ComparisonOperator.LESS_THAN || comp.getOperator() == ComparisonOperator.LESS_OR_EQUAL)
                 && comp.getRightOperand().isNumeric())
-            return translate((DistanceFunction) comp.getLeftOperand(), translate(comp.getRightOperand()).toString());
+            return translate((DistanceFunction) comp.getLeftOperand(), translate(comp.getRightOperand()));
         else if ((comp.getRightOperand() instanceof DistanceFunction)
                 && (comp.getOperator() == ComparisonOperator.LESS_THAN || comp.getOperator() == ComparisonOperator.LESS_OR_EQUAL)
                 && comp.getLeftOperand().isNumeric())
-            return translate((DistanceFunction) comp.getRightOperand(), translate(comp.getLeftOperand()).toString());
+            return translate((DistanceFunction) comp.getRightOperand(), translate(comp.getLeftOperand()));
         else
             return super.translate(comp);
     }

--- a/ADQLLib/src/adql/translator/MAST_Q3CTranslator.java
+++ b/ADQLLib/src/adql/translator/MAST_Q3CTranslator.java
@@ -10,6 +10,11 @@ import adql.query.operand.function.geometry.IntersectsFunction;
  * MAST-specific Postgres/Q3C translator.
  * 
  * Uses q3c_join() instead of default q3c_dist() for distance comparisons.
+ * 
+ * Note: q3c_join() is boundary-inclusive, so {@code <=} only is supported.
+ * {@code <} comparisons default to the q3c_dist() implementation in the parent class.
+ * However, in practice, the odds of a point being exactly on the boundary are extremely low, so this should not be an issue.
+ * 
  */
 public class MAST_Q3CTranslator extends Q3CTranslator {
 
@@ -37,11 +42,11 @@ public class MAST_Q3CTranslator extends Q3CTranslator {
     @Override
     public String translate(Comparison comp) throws TranslationException {
         if ((comp.getLeftOperand() instanceof DistanceFunction)
-                && (comp.getOperator() == ComparisonOperator.LESS_THAN || comp.getOperator() == ComparisonOperator.LESS_OR_EQUAL)
+                && (comp.getOperator() == ComparisonOperator.LESS_OR_EQUAL)
                 && comp.getRightOperand().isNumeric())
             return translate((DistanceFunction) comp.getLeftOperand(), translate(comp.getRightOperand()));
         else if ((comp.getRightOperand() instanceof DistanceFunction)
-                && (comp.getOperator() == ComparisonOperator.LESS_THAN || comp.getOperator() == ComparisonOperator.LESS_OR_EQUAL)
+                && (comp.getOperator() == ComparisonOperator.LESS_OR_EQUAL)
                 && comp.getLeftOperand().isNumeric())
             return translate((DistanceFunction) comp.getRightOperand(), translate(comp.getLeftOperand()));
         else

--- a/ADQLLib/src/adql/translator/MAST_Q3CTranslator.java
+++ b/ADQLLib/src/adql/translator/MAST_Q3CTranslator.java
@@ -8,9 +8,8 @@ import adql.query.operand.function.geometry.IntersectsFunction;
 
 /**
  * MAST-specific Postgres/Q3C translator.
- *
- * This class intentionally keeps the default Q3C behavior in place until the
- * MAST-specific DISTANCE/CONTAINS/INTERSECTS semantics are implemented.
+ * 
+ * Uses q3c_join() instead of default q3c_dist() for distance comparisons.
  */
 public class MAST_Q3CTranslator extends Q3CTranslator {
 

--- a/ADQLLib/src/adql/translator/MAST_Q3CTranslator.java
+++ b/ADQLLib/src/adql/translator/MAST_Q3CTranslator.java
@@ -31,7 +31,6 @@ public class MAST_Q3CTranslator extends Q3CTranslator {
         str.append(translate(fct.getP2())).append(",");
         str.append(radius);
         str.append(")");
-        str.append(" = 1"); 
         return str.toString();
     }
 

--- a/ADQLLib/src/adql/translator/MAST_Q3CTranslator.java
+++ b/ADQLLib/src/adql/translator/MAST_Q3CTranslator.java
@@ -35,16 +35,6 @@ public class MAST_Q3CTranslator extends Q3CTranslator {
     }
 
     @Override
-    public String translate(ContainsFunction fct) throws TranslationException {
-        return super.translate(fct);
-    }
-
-    @Override
-    public String translate(IntersectsFunction fct) throws TranslationException {
-        return super.translate(fct);
-    }
-
-    @Override
     public String translate(Comparison comp) throws TranslationException {
         if ((comp.getLeftOperand() instanceof DistanceFunction)
                 && (comp.getOperator() == ComparisonOperator.LESS_THAN || comp.getOperator() == ComparisonOperator.LESS_OR_EQUAL)

--- a/ADQLLib/src/adql/translator/MAST_Q3CTranslator.java
+++ b/ADQLLib/src/adql/translator/MAST_Q3CTranslator.java
@@ -32,7 +32,6 @@ public class MAST_Q3CTranslator extends Q3CTranslator {
         str.append(translate(fct.getP2())).append(",");
         str.append(radius);
         str.append(")");
-        str.append(" = 1"); 
         return str.toString();
     }
 
@@ -48,19 +47,7 @@ public class MAST_Q3CTranslator extends Q3CTranslator {
 
     @Override
     public String translate(Comparison comp) throws TranslationException {
-        if ((comp.getLeftOperand() instanceof ContainsFunction || comp.getLeftOperand() instanceof IntersectsFunction)
-                &&
-                (comp.getOperator() == ComparisonOperator.EQUAL || comp.getOperator() == ComparisonOperator.NOT_EQUAL)
-                && comp.getRightOperand().isNumeric())
-            return translate(comp.getLeftOperand()) + " " + comp.getOperator().toADQL() + " '"
-                    + translate(comp.getRightOperand()) + "'";
-        else if ((comp.getRightOperand() instanceof ContainsFunction
-                || comp.getRightOperand() instanceof IntersectsFunction)
-                && (comp.getOperator() == ComparisonOperator.EQUAL || comp.getOperator() == ComparisonOperator.NOT_EQUAL)
-                && comp.getLeftOperand().isNumeric())
-            return "'" + translate(comp.getLeftOperand()) + "' " + comp.getOperator().toADQL() + " "
-                    + translate(comp.getRightOperand());
-        else if ((comp.getLeftOperand() instanceof DistanceFunction)
+        if ((comp.getLeftOperand() instanceof DistanceFunction)
                 && (comp.getOperator() == ComparisonOperator.LESS_THAN || comp.getOperator() == ComparisonOperator.LESS_OR_EQUAL)
                 && comp.getRightOperand().isNumeric())
             return translate((DistanceFunction) comp.getLeftOperand(), translate(comp.getRightOperand()).toString());

--- a/ADQLLib/test/adql/translator/TestQ3CTranslator.java
+++ b/ADQLLib/test/adql/translator/TestQ3CTranslator.java
@@ -119,4 +119,44 @@ public class TestQ3CTranslator {
 
 		}
 	}
+	
+	@Test
+	public void testMASTCrossmatch(){
+    // Same crossmatch query as testCrossmatch(), but using <= so that
+    // MAST_Q3CTranslator uses q3c_join() instead of q3c_dist().
+    try{
+        String adqlquery = 
+			"SELECT TOP 100 geo_aTable.*, bTable.* " +
+			"FROM (" +
+			"    SELECT * FROM aTable" +
+			"    WHERE DISTANCE(POINT('ICRS', 187.11, 11.58), POINT('ICRS', ra, dec)) <= 0.5 )" +
+			"    AS geo_aTable " +
+			"JOIN bTable ON " +
+			"    DISTANCE(POINT('ICRS', geo_aTable.ra, geo_aTable.dec), POINT('ICRS', bTable.ra, bTable.dec)) <= 0.01";
+
+        ADQLParser parser = new ADQLParser(ADQLVersion.V2_1);
+        parser.setQueryChecker(new DBChecker(tables));
+
+        ADQLSet query = parser.parseQuery(adqlquery);
+        MAST_Q3CTranslator translator = new MAST_Q3CTranslator();
+
+        String translated = translator.translate(query);
+		
+		String expectedQuery = 
+		"SELECT geo_atable.id AS \"id\" , geo_atable.name AS \"name\" , geo_atable.ra AS \"ra\" , geo_atable.dec AS \"dec\" , bTable.id AS \"id\" , bTable.name AS \"name\" , bTable.ra AS \"ra\" , bTable.dec AS \"dec\"\n" +
+		"FROM (SELECT aTable.id AS \"id\" , aTable.name AS \"name\" , aTable.ra AS \"ra\" , aTable.dec AS \"dec\"\n"+
+		"FROM aTable\n" +
+		"WHERE q3c_join(187.11,11.58,aTable.ra,aTable.dec,0.5)) AS \"geo_atable\" INNER JOIN bTable ON q3c_join(geo_atable.ra,geo_atable.dec,bTable.ra,bTable.dec,0.01)\n"+
+		"LIMIT 100";
+		
+		assertEquals(expectedQuery, translated);
+
+    }catch(ParseException pe){
+        pe.printStackTrace();
+        fail("The given ADQL query is completely correct. No error should have occurred while parsing it. (see the console for more details)");
+    }catch(TranslationException te){
+        te.printStackTrace();
+        fail("No error was expected from this translation. (see the console for more details)");
+    }
+}
 }

--- a/ADQLLib/test/adql/translator/TestQ3CTranslator.java
+++ b/ADQLLib/test/adql/translator/TestQ3CTranslator.java
@@ -92,4 +92,25 @@ public class TestQ3CTranslator {
 			fail("No error was expected from this translation. (see the console for more details)");
 		}
 	}
+	
+	@Test
+	public void testPointsDistanceMAST() {
+		try {
+			String adqlquery = "SELECT top 1 * FROM aTable WHERE DISTANCE(POINT('ICRS', 187.11, 11.58), POINT('ICRS', 187.15, 12)) < 0.5";
+
+			ADQLParser parser = new ADQLParser(ADQLVersion.V2_1, new DBChecker(tables), new ADQLQueryFactory(), null);
+			ADQLSet query = parser.parseQuery(adqlquery);
+			MAST_Q3CTranslator translator = new MAST_Q3CTranslator();
+
+			assertTrue(translator.translate(query).contains("q3c_join(187.11,11.58,187.15,12,0.5) = 1"));
+
+		} catch (ParseException pe) {
+			pe.printStackTrace();
+			fail("The given ADQL query is completely correct. No error should have occurred while parsing it. (see the console for more details)");
+		} catch (TranslationException te) {
+			te.printStackTrace();
+			fail("No error was expected from this translation. (see the console for more details)");
+
+		}
+	}
 }

--- a/ADQLLib/test/adql/translator/TestQ3CTranslator.java
+++ b/ADQLLib/test/adql/translator/TestQ3CTranslator.java
@@ -97,7 +97,7 @@ public class TestQ3CTranslator {
 	@Test
 	public void testPointsDistanceMAST() {
 		try {
-			String adqlquery = "SELECT top 1 * FROM aTable WHERE DISTANCE(POINT('ICRS', 187.11, 11.58), POINT('ICRS', 187.15, 12)) < 0.5";
+			String adqlquery = "SELECT top 1 * FROM aTable WHERE DISTANCE(POINT('ICRS', 187.11, 11.58), POINT('ICRS', 187.15, 12)) <= 0.5";
 
 			ADQLParser parser = new ADQLParser(ADQLVersion.V2_1, new DBChecker(tables), new ADQLQueryFactory(), null);
 			ADQLSet query = parser.parseQuery(adqlquery);

--- a/ADQLLib/test/adql/translator/TestQ3CTranslator.java
+++ b/ADQLLib/test/adql/translator/TestQ3CTranslator.java
@@ -1,5 +1,6 @@
 package adql.translator;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -102,7 +103,12 @@ public class TestQ3CTranslator {
 			ADQLSet query = parser.parseQuery(adqlquery);
 			MAST_Q3CTranslator translator = new MAST_Q3CTranslator();
 
-			assertTrue(translator.translate(query).contains("q3c_join(187.11,11.58,187.15,12,0.5)"));
+			assertEquals(
+			"SELECT aTable.id AS \"id\" , aTable.name AS \"name\" , aTable.ra AS \"ra\" , aTable.dec AS \"dec\"\n"+
+			"FROM aTable\n" +
+			"WHERE q3c_join(187.11,11.58,187.15,12,0.5)\n" +
+			"LIMIT 1", translator.translate(query));
+			
 
 		} catch (ParseException pe) {
 			pe.printStackTrace();

--- a/ADQLLib/test/adql/translator/TestQ3CTranslator.java
+++ b/ADQLLib/test/adql/translator/TestQ3CTranslator.java
@@ -102,7 +102,7 @@ public class TestQ3CTranslator {
 			ADQLSet query = parser.parseQuery(adqlquery);
 			MAST_Q3CTranslator translator = new MAST_Q3CTranslator();
 
-			assertTrue(translator.translate(query).contains("q3c_join(187.11,11.58,187.15,12,0.5) = 1"));
+			assertTrue(translator.translate(query).contains("q3c_join(187.11,11.58,187.15,12,0.5)"));
 
 		} catch (ParseException pe) {
 			pe.printStackTrace();


### PR DESCRIPTION
Following a discussion with John Gossick and Ben Jordan, it is now recommended that we use `q3c_join` rather than `q3c_dist` for DISTANCE calculations on the Greenplum DB's.

Rather than overriding the distance translation method in Q3CTranslator.java, I spun off a `MAST_Q3CTranslator` class. 

Using `q3c_join` was slightly more involved than just swapping out the string function name, since `q3c_join` takes `ra, dec, ra2, dec2, r`, rather than just the positions and a boolean comparison. 

Otherwise, the functionality remains the same. This was deployed to DEV/TEST and appeared to be fine.